### PR TITLE
adding support for major release sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/vsoch/pipelib/tree/main) (0.0.x)
+ - support for major tag sort (0.0.14)
  - bug that re-using pipeline will remove steps (0.0.13)
  - shared operator for AND / OR (0.0.12)
  - removing deprecated distutils.LooseVersion (0.0.11)

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -350,6 +350,40 @@ And finally, just major.
     ['0.9.36.0']
 
 
+.. _getting_started-user-guide-usage-github-tags:
+
+
+A Real World Example - GitHub Tags
+----------------------------------
+
+If you want to filter down GitHub tags to semantic versions, you're best off using
+the ``ContainerTagSort`` described previously. However, for some trusted actions,
+we want to stick with a major tag or release like ``v3``. This is what this
+step is intended for.
+
+.. code-block:: python
+
+    import pipelib.steps as step
+    import pipelib.pipeline as pipeline
+
+    # Pre-generated sets of steps we can use
+    import pipelib.pipelines as pipelines
+
+    # Example GitHub release tags
+    tags = ['v3', 'v2', 'v2.5.1']
+
+    # A pipeline to process docker tags
+    steps = (
+
+       # Parse versions, return sorted ascending, and taking version major.minor.patch into account
+       step.release.MajorTagSort()
+    )
+
+    p = pipeline.Pipeline(steps)
+    # The updated and transformed items
+    updated = p.run(tags)
+
+
 Steps
 -----
 
@@ -376,6 +410,7 @@ You can easily look at the steps that are provided:
       'ToLowercase': pipelib.steps.transform.strings.ToLowercase,
       'ToString': pipelib.steps.transform.strings.ToString},
      'container': {'ContainerTagSort': pipelib.steps.container.tags.ContainerTagSort},
-     'sort': {'BasicSort': pipelib.steps.sort.basic.BasicSort}}
+     'sort': {'BasicSort': pipelib.steps.sort.basic.BasicSort},
+     'release': {'MajorTagSort': pipelib.steps.release.tags.MajorTagSort}}
     
 This library is under development and we will have more documentation coming soon!

--- a/pipelib/steps/__init__.py
+++ b/pipelib/steps/__init__.py
@@ -2,12 +2,14 @@ from . import filters
 from . import transform
 from . import container
 from . import sort
+from . import release
 
 all_steps = {
     "filter": filters._lookup,
     "transform": transform._lookup,
     "container": container._lookup,
     "sort": sort._lookup,
+    "release": release._lookup,
 }
 
 

--- a/pipelib/steps/release/__init__.py
+++ b/pipelib/steps/release/__init__.py
@@ -1,0 +1,8 @@
+import pipelib.utils as utils
+import os
+
+_lookup = {}
+here = os.path.abspath(os.path.dirname(__file__))
+for obj, imported in utils.dynamic_import(__name__, here):
+    globals()[obj] = imported
+    _lookup[obj] = imported

--- a/pipelib/steps/release/tags.py
+++ b/pipelib/steps/release/tags.py
@@ -44,8 +44,9 @@ class MajorTagSort(step.BaseStep):
         for version in items:
 
             # Keep all that are only major versions
-            if version.major and not version.major_minor:
+            if version.major and not version.major_minor and version not in seen:
                 filtered.append(version)
+                seen.add(version)
                 continue
 
         # By default from above they are decending, greatest (newest) to least (oldest)

--- a/pipelib/steps/release/tags.py
+++ b/pipelib/steps/release/tags.py
@@ -1,0 +1,54 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2022, Vanessa Sochat"
+__license__ = "MPL 2.0"
+
+from pipelib.steps import step
+import pipelib.wrappers as wrappers
+
+# Major tags sort
+
+class MajorTagSort(step.BaseStep):
+    """
+    Parse versions that have only major versions (e.g., v3)
+    An example of this is GitHub releases - e.g., we often just want @v3.
+
+    >>> from pipelib.pipeline import Pipeline
+    >>> pipeline = Pipeline(MajorTagSort(ascending=True))
+    >>> pipeline.run(["1.2.3", "1.2.1"])
+    []
+    >>> pipeline = Pipeline(MajorTagSort(ascending=False))
+    >>> pipeline = Pipeline(ContainerTagSort(ascending=False))
+    >>> pipeline.run(["v3", "1.2.3", "v2"])
+    ['v1', 'v3']
+    >>> pipeline = Pipeline(MajorTagSort(ascending=True))
+    >>> pipeline.run(["v3", "1.2.3", "v2"])
+    ['v3', 'v1']
+    """
+    def run(self, items: list) -> list:
+        """
+        Wrap in a LooseVersion to allow sort and filter of tags.
+        """
+        ascending = self.kwargs.get("ascending")
+
+        # Convert to LooseVersionWrapper
+        items = [wrappers.VersionWrapper(x) for x in items]
+
+        # The sorting will tag a subset with "remove" that aren't sortable
+        # This has latest at the top so we grab newest versions of each
+        items.sort(reverse=True)
+
+        # Now only take the top major / minor of each
+        filtered = []
+        seen = set()
+
+        for version in items:
+
+            # Keep all that are only major versions
+            if version.major and not version.major_minor:
+                filtered.append(version)
+                continue
+
+        # By default from above they are decending, greatest (newest) to least (oldest)
+        if ascending:
+            filtered.sort()
+        return filtered

--- a/pipelib/version.py
+++ b/pipelib/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "pipelib"


### PR DESCRIPTION
This will close #5. Instead of tweaking container tag sort (where we really want semver) I made a new pipeline step.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>