### PR TITLE
Ensure VersionWrapper is hashable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/vsoch/pipelib/tree/main) (0.0.x)
+ - bug that VersionWrapper wasn't hashable (0.0.17)
  - support for new variant of packaging (0.0.16)
  - skip empty version strings in container tags (0.0.15)
  - support for major tag sort (0.0.14)

--- a/pipelib/tests/test_steps.py
+++ b/pipelib/tests/test_steps.py
@@ -10,6 +10,7 @@ import pytest
 
 import pipelib.utils
 from pipelib.steps import iter_steps
+from pipelib.steps.release.tags import MajorTagSort
 
 
 @pytest.mark.parametrize("step_type,step_name,step_module", list(iter_steps()))
@@ -25,3 +26,18 @@ def test_step(tmp_path, step_type, step_name, step_module):
         if ">>>" in line:
             has_code = True
     assert has_code
+
+
+def test_release_tags() -> None:
+    """
+    Tests for MajorTagSort
+    """
+    items = ["v3", "v1", "v2-beta", "v2"]
+
+    step = MajorTagSort(ascending=True)
+    filtered = step.run(items)
+    assert [str(x) for x in filtered] == ["v1", "v2-beta", "v3"]
+
+    step = MajorTagSort(ascending=False)
+    filtered = step.run(items)
+    assert [str(x) for x in filtered] == ["v3", "v2-beta", "v1"]

--- a/pipelib/tests/test_wrappers.py
+++ b/pipelib/tests/test_wrappers.py
@@ -1,0 +1,20 @@
+from pipelib.wrappers.version import VersionWrapper
+
+
+def test_versionwrapper() -> None:
+    """
+    Test basic functionality for VersionWrapper
+    """
+    major = VersionWrapper("3")
+    major_minor = VersionWrapper("3.2")
+    major_minor_patch = VersionWrapper("3.2.5")
+    major_minor_patch_dup = VersionWrapper("3.2.5")
+
+    assert major.version == [3]
+    assert major_minor.version == [3, 2]
+    assert major_minor_patch.version == [3, 2, 5]
+
+    assert major < major_minor
+    assert major_minor < major_minor_patch
+
+    assert hash(major_minor_patch_dup) == hash(major_minor_patch_dup)

--- a/pipelib/version.py
+++ b/pipelib/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "pipelib"

--- a/pipelib/wrappers/version.py
+++ b/pipelib/wrappers/version.py
@@ -81,6 +81,9 @@ class VersionWrapper(Wrapper, LooseVersion):
         self.version = components
         print(f"Setting version to {self.version}")
 
+    def __hash__(self) -> int:
+        return hash(tuple(self.version))
+
     def __lt__(self, other) -> bool:
         return self.version < other.version
 


### PR DESCRIPTION
I encountered this when trying to run `action-updater` on a repo:
```
$ action-updater detect .github/workflows/test.yml
⭐️ .github/workflows/test.yml
✔ Save-state: No updates
✔ Set-env: No updates
Setting version to [1]
Setting version to [2]
Setting version to [2]
Setting version to [3]
Traceback (most recent call last):
  File "/home/eric/data/virtualenvs/action-updater/bin/action-updater", line 8, in <module>
    sys.exit(run_action_updater())
             ^^^^^^^^^^^^^^^^^^^^
  File "/home/eric/data/virtualenvs/action-updater/lib/python3.11/site-packages/action_updater/client/__init__.py", line 201, in run_action_updater
    main(args=args, parser=parser, extra=extra, subparser=helper)
  File "/home/eric/data/virtualenvs/action-updater/lib/python3.11/site-packages/action_updater/client/detect.py", line 17, in main
    cli.detect(paths=args.paths, details=not args.no_details, updaters=parse_updaters(args))
  File "/home/eric/data/virtualenvs/action-updater/lib/python3.11/site-packages/action_updater/main/client.py", line 92, in detect
    if updater.detect(action):
       ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/eric/data/virtualenvs/action-updater/lib/python3.11/site-packages/action_updater/main/updaters/version/update.py", line 62, in detect
    updated = self.get_major_tag(tags)
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/eric/data/virtualenvs/action-updater/lib/python3.11/site-packages/action_updater/main/updaters/version/update.py", line 110, in get_major_tag
    ordered = sort_major(tags_list)
              ^^^^^^^^^^^^^^^^^^^^^
  File "/home/eric/data/virtualenvs/action-updater/lib/python3.11/site-packages/action_updater/main/github.py", line 39, in sort_major
    return p.run(list(tags), unwrap=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/eric/data/virtualenvs/action-updater/lib/python3.11/site-packages/pipelib/pipeline.py", line 84, in run
    items = step.run(items=items, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/eric/data/virtualenvs/action-updater/lib/python3.11/site-packages/pipelib/steps/release/tags.py", line 48, in run
    if version.major and not version.major_minor and version not in seen:
                                                     ^^^^^^^^^^^^^^^^^^^
TypeError: unhashable type: 'VersionWrapper'
```
and saw that there wasn't any test coverage through `MajorTagSort`.